### PR TITLE
feat(store):Create a zustand store for bases

### DIFF
--- a/src/Map/BaseStore.ts
+++ b/src/Map/BaseStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import type { Station } from "./types";
+
+type BaseState = {
+    bases: Station[];
+}
+
+type BaseAction = {
+    addStation: (base: Station) => void
+}
+
+export const useBaseStore = create<BaseState & BaseAction>((set) => ({
+    bases: [
+        { stationType: 'huvudbas', coordinates: [60.073774388521656, 16.808927085708422], id: 'asdfoasjdfoajsodf' },
+        { stationType: 'reservbas', coordinates: [60.13882461404783, 14.123980863454367], id: 'iosajdgouiasdfiais' },
+        { stationType: 'sidobas', coordinates: [60.66805933137298, 14.070586699767079], id: 'asodfoasdjfoasdfjas' },
+        { stationType: 'reservbas', coordinates: [59.268549179577285, 14.266775673332363], id: 'aoisdfiuahsdiufhaiusdfgiuasd' },
+    ],
+    addStation: (base) => set((state) => ({ bases: [...state.bases, base] }))
+}))

--- a/src/Map/StationsLayer.tsx
+++ b/src/Map/StationsLayer.tsx
@@ -1,15 +1,9 @@
 import { FeatureGroup } from "react-leaflet";
 import MapMarker from "./MapMarker";
-import type { Station } from "./types";
-
-const stations: Station[] = [
-    { stationType: 'huvudbas', coordinates: [60.073774388521656, 16.808927085708422], id: 'asdfoasjdfoajsodf' },
-    { stationType: 'reservbas', coordinates: [60.13882461404783, 14.123980863454367], id: 'iosajdgouiasdfiais' },
-    { stationType: 'sidobas', coordinates: [60.66805933137298, 14.070586699767079], id: 'asodfoasdjfoasdfjas' },
-    { stationType: 'reservbas', coordinates: [59.268549179577285, 14.266775673332363], id: 'aoisdfiuahsdiufhaiusdfgiuasd' },
-]
+import { useBaseStore } from "./BaseStore";
 
 export default function StationsLayer() {
+    const stations = useBaseStore((state) => (state.bases));
     return (
         <FeatureGroup>
             {


### PR DESCRIPTION
Fixed #7 and fixed #8

- Created a zustand store that contains a state for bases and an action to add a base.
- The action also makes the base render on the map. 